### PR TITLE
feat: add option: hideResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ fastify.register(customHealthCheck, {
     -   default value: `false`
 -   schema: If set to true, default schema is used for the route definition, if to false - no schema. If object is passed, it will be used as a schema. This can be used to enable support for custom type providers, e. g. zod or typebox. 
     -   default value: `true`
+-   hideResponse: If set to true, when your system gets hit with the path, fastify is not going to log that it was hit. This makes the logs cleaner, but also eliminates any logs generated. It has no bearing on the response of the plugin, however.
+    -   default value: `false`
 
 ### Decorator
 
@@ -86,7 +88,7 @@ fastify.addHealthCheck(label, () => {}, { value: true });
     }
   },
   "info": {
-    "example": "Response",
+    "example": "Response"
   }
 }
 ```

--- a/example/server.js
+++ b/example/server.js
@@ -1,11 +1,14 @@
-const fastify = require('fastify')();
+const fastify = require('fastify')({
+  logger: true // this is needed to show the example of 'hideResponse'
+});
 const MongoClient = require('mongodb').MongoClient;
 const customHealthCheck = require('../lib');
 const url = 'mongodb://localhost:27017';
 const _package = require('../package.json');
 
 fastify.register(customHealthCheck, {
-  path: '/custom/path/health',
+  path: '/health',
+  hideResponse: true, // remove this or set to false to show the response in the log
   info: {
     example: 'Custom Info',
     env: process.env.NODE_ENV,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,6 +10,11 @@ export interface CustomHealthCheckOptions {
   exposeFailure?: boolean;
   /** If set to true, default schema is used for the route definition, if to false - no schema. If object is passed, it will be used as a schema. Default value is "true" */
   schema?: boolean | Record<string, any>
+  /** If set to true, when your system gets hit with the path,
+   * fastify is not going to log that it was hit.
+   * This makes the logs cleaner, but also eliminates any logs generated.
+   * It has no bearing on the response of the plugin, however. */
+  hideResponse?: boolean;
 }
 
 declare module 'fastify' {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,6 @@
-import { FastifyPlugin } from 'fastify';
+import {
+  FastifyPluginCallback
+} from "fastify";
 import { addHealthCheck } from './src/customHealthCheck';
 
 export interface CustomHealthCheckOptions {
@@ -6,9 +8,13 @@ export interface CustomHealthCheckOptions {
   path?: string;
   /** Object where you can define custom information you would like to include in healthcheck response */
   info?: Record<string, string>;
-  /** Flag that enables additional information to be presented in health check object when a check fails. */
+  /** Flag that enables additional information
+   * to be presented in a health check object when a check fails. */
   exposeFailure?: boolean;
-  /** If set to true, default schema is used for the route definition, if to false - no schema. If object is passed, it will be used as a schema. Default value is "true" */
+  /** If set to true, default schema is used for the route definition,
+   * if to false - no schema.
+   * If an object is passed, it will be used as a schema.
+   * The Default value is "true" */
   schema?: boolean | Record<string, any>
   /** If set to true, when your system gets hit with the path,
    * fastify is not going to log that it was hit.
@@ -23,5 +29,5 @@ declare module 'fastify' {
   }
 }
 
-declare const customHealthCheck: FastifyPlugin<CustomHealthCheckOptions>;
+declare const customHealthCheck: FastifyPluginCallback<CustomHealthCheckOptions>;
 export default customHealthCheck;

--- a/lib/src/customHealthCheck.js
+++ b/lib/src/customHealthCheck.js
@@ -17,7 +17,7 @@ function resolveSchema (options) {
 }
 
 function customHealthCheck (fastify, options, next) {
-  const { path = '/health', info = undefined, exposeFailure = false, ...rest } = options;
+  const { path = '/health', hideResponse = false, info = undefined, exposeFailure = false, ...rest } = options;
   const healthChecks = [];
 
   fastify.decorate('addHealthCheck', function (label, fn, evaluation = null) {
@@ -29,7 +29,7 @@ function customHealthCheck (fastify, options, next) {
   });
 
   const resolvedSchema = resolveSchema(options);
-  fastify.get(path, { ...rest, schema: resolvedSchema }, (req, res) =>
+  fastify.get(path, { ...rest, logLevel: (hideResponse === false) ? 'info' : 'silent', schema: resolvedSchema }, (req, res) =>
     Controller(req, res, { healthChecks, info, stats: getStats(), exposeFailure })
   );
 

--- a/lib/tests/customHealthCheck.test.js
+++ b/lib/tests/customHealthCheck.test.js
@@ -33,9 +33,19 @@ describe('Custom Health Check', () => {
   });
 
   describe('When registering path', () => {
+    it('Should be logLevel `silent` when hideResponse true  ', (done) => {
+      customHealthCheck(fastify, { mock: 'option', hideResponse: true }, () => {
+        expect(getSpy).toHaveBeenCalledWith('/health', { logLevel: 'silent', schema, mock: 'option' }, expect.any(Function));
+
+        done();
+      });
+    });
+  });
+
+  describe('When registering path', () => {
     it('Should add a default path', (done) => {
       customHealthCheck(fastify, { mock: 'option' }, () => {
-        expect(getSpy).toHaveBeenCalledWith('/health', { schema, mock: 'option' }, expect.any(Function));
+        expect(getSpy).toHaveBeenCalledWith('/health', { logLevel: 'info', schema, mock: 'option' }, expect.any(Function));
 
         done();
       });
@@ -43,15 +53,15 @@ describe('Custom Health Check', () => {
 
     it('Should add path provided', (done) => {
       customHealthCheck(fastify, { mock: 'option', path: '/mock/path' }, () => {
-        expect(getSpy).toHaveBeenCalledWith('/mock/path', { schema, mock: 'option' }, expect.any(Function));
+        expect(getSpy).toHaveBeenCalledWith('/mock/path', { logLevel: 'info', schema, mock: 'option' }, expect.any(Function));
 
         done();
       });
     });
 
     it('Should set controller to get path', (done) => {
-      customHealthCheck(fastify, { mock: 'option', info: 'mockInfo' }, () => {
-        expect(getSpy).toHaveBeenCalledWith('/health', { schema, mock: 'option' }, expect.any(Function));
+      customHealthCheck(fastify, { hideResponse: false, mock: 'option', info: 'mockInfo' }, () => {
+        expect(getSpy).toHaveBeenCalledWith('/health', { logLevel: 'info', schema, mock: 'option' }, expect.any(Function));
         expect(ControllerMock.ControllerSpy).toHaveBeenCalledWith({}, {}, {
           healthChecks: [],
           info: 'mockInfo',

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fastify-plugin": "^4.0.0"
+    "fastify-plugin": "^5.0.1"
   },
   "devDependencies": {
-    "fastify": "^4.0.0",
-    "fastify-type-provider-zod": "^1.1.7",
-    "jest": "^29.0.1",
-    "mongodb": "^4.7.0",
-    "semistandard": "^16.0.1",
+    "fastify": "^5.2.0",
+    "fastify-type-provider-zod": "^4.0.2",
+    "jest": "^29.7.0",
+    "mongodb": "^6.12.0",
+    "semistandard": "^17.0.0",
     "snazzy": "^9.0.0",
-    "zod": "^3.19.1"
+    "zod": "^3.24.1"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
When I am doing debugging of my fustily application in kuberntess, it be nice for the ```livenessProbe``` and ```readinessProbe``` not spammy in the console logs and just not show up. This just does that.

Unit tests created. 👍 